### PR TITLE
bug: fix `swith` to `switch` in Update Get-ElapsedTime.ps1

### DIFF
--- a/Get-ElapsedTime.ps1
+++ b/Get-ElapsedTime.ps1
@@ -88,7 +88,7 @@ function Get-ElapsedTime
 		[switch]
 		$Minutes,
 		[Parameter(ParameterSetName = 'Seconds')]
-		[swith]
+		[switch]
 		$Seconds,
 		[Parameter(ParameterSetName = 'TotalDays')]
 		[switch]


### PR DESCRIPTION
See https://github.com/PsCustomObject/PowerShell-Functions/blob/33a9762c40bea43f14f5cca674ecffa33b248cd4/Get-ElapsedTime.ps1#L91