### PR TITLE
Update Get-ElapsedTime.ps1

### DIFF
--- a/Get-ElapsedTime.ps1
+++ b/Get-ElapsedTime.ps1
@@ -1,183 +1,41 @@
-function Get-ElapsedTime
-{
-	<#
-		.SYNOPSIS
-			Will return information about elapsed time for the given StopWatch.
-		
-		.DESCRIPTION
-			Function requires a [System.Diagnostics.Stopwatch] object as input and will output information about elapsed time.
-			
-			By default a [TimeSpan] object is returned containing all information about elapsed time.
-			
-			If any other parameter like -Days is used function will return an Int or Double instead depending on the switch used.
-		
-		.PARAMETER ElapsedTime
-			Will return a [TimeSpan] object representing the elapsed time for the given stopwatch.
-		
-		.PARAMETER Days
-			Will return an [Int] object representing the number of days since the stopwatch was started.
-		
-		.PARAMETER Hours
-			Will return an [Int] object representing the number of hours since the stopwatch was started.
-		
-		.PARAMETER Minutes
-			Will return an [Int] object representing the number of minutes since the stopwatch was started.
-		
-		.PARAMETER Seconds
-			Will return an [Int] object representing the number of seconds since the stopwatch was started.
-		
-		.PARAMETER TotalDays
-			Will return a [Double] object representing the number of TotalDays since the stopwatch was started.
-		
-		.PARAMETER TotalHours
-			Will return a [Double] object representing the number of TotalHours since the stopwatch was started.
-		
-		.PARAMETER TotalMinutes
-			Will return a [Double] object representing the number of TotalMinutes since the stopwatch was started.
-		
-		.PARAMETER TotalSeconds
-			Will return a [Double] object representing the number of TotalSeconds since the stopwatch was started.
-		
-		.PARAMETER TotalMilliseconds
-			Will return a [Double] object representing the number of TotalMilliseconds since the stopwatch was started.
-		
-		.EXAMPLE
-			PS C:\> Get-ElapsedTime -ElapsedTime $ElapsedTime -Days
-		
-		.OUTPUTS
-			System.TimeSpan, System.Double, System.Int32
-	#>
-		
-	[CmdletBinding(DefaultParameterSetName = 'FullOutput',
-				   ConfirmImpact = 'High',
-				   SupportsPaging = $false,
-				   SupportsShouldProcess = $false)]
-	[OutputType([timespan], ParameterSetName = 'FullOutput')]
-	[OutputType([int], ParameterSetName = 'Days')]
-	[OutputType([int], ParameterSetName = 'Hours')]
-	[OutputType([int], ParameterSetName = 'Minutes')]
-	[OutputType([int], ParameterSetName = 'Seconds')]
-	[OutputType([double], ParameterSetName = 'TotalDays')]
-	[OutputType([double], ParameterSetName = 'TotalHours')]
-	[OutputType([double], ParameterSetName = 'TotalMinutes')]
-	[OutputType([double], ParameterSetName = 'TotalSeconds')]
-	[OutputType([double], ParameterSetName = 'TotalMilliseconds')]
-	[OutputType([timespan])]
-	param
-	(
-		[Parameter(ParameterSetName = 'FullOutput',
-				   Mandatory = $true)]
-		[Parameter(ParameterSetName = 'Days')]
-		[Parameter(ParameterSetName = 'Hours')]
-		[Parameter(ParameterSetName = 'Minutes')]
-		[Parameter(ParameterSetName = 'Seconds')]
-		[Parameter(ParameterSetName = 'TotalDays')]
-		[Parameter(ParameterSetName = 'TotalHours')]
-		[Parameter(ParameterSetName = 'TotalMilliseconds')]
-		[Parameter(ParameterSetName = 'TotalMinutes')]
-		[Parameter(ParameterSetName = 'TotalSeconds')]
-		[System.Diagnostics.Stopwatch]
-		$ElapsedTime,
-		[Parameter(ParameterSetName = 'Days')]
-		[switch]
-		$Days,
-		[Parameter(ParameterSetName = 'Hours')]
-		[switch]
-		$Hours,
-		[Parameter(ParameterSetName = 'Minutes')]
-		[switch]
-		$Minutes,
-		[Parameter(ParameterSetName = 'Seconds')]
-		[switch]
-		$Seconds,
-		[Parameter(ParameterSetName = 'TotalDays')]
-		[switch]
-		$TotalDays,
-		[Parameter(ParameterSetName = 'TotalHours')]
-		[switch]
-		$TotalHours,
-		[Parameter(ParameterSetName = 'TotalMinutes')]
-		[switch]
-		$TotalMinutes,
-		[Parameter(ParameterSetName = 'TotalSeconds')]
-		[switch]
-		$TotalSeconds,
-		[Parameter(ParameterSetName = 'TotalMilliseconds')]
-		[switch]
-		$TotalMilliseconds
-	)
-	
-	switch ($PsCmdlet.ParameterSetName)
-	{
-		'FullOutput'
-		{
-			# Return full timespan object
-			return $ElapsedTime.Elapsed
-			
-			break
-		}
-		'Days'
-		{
-			# Return days with no decimals
-			return $ElapsedTime.Elapsed.Days
-			
-			break
-		}
-		'Hours'
-		{
-			# Return hours with no decimals
-			return $ElapsedTime.Elapsed.Hours
-			
-			break
-		}
-		'Minutes'
-		{
-			# Return minutes with no decimals
-			return $ElapsedTime.Elapsed.Minutes
-			
-			break
-		}
-		'Seconds'
-		{
-			# Return seconds with no decimals
-			return $ElapsedTime.Elapsed.Seconds
-			
-			break
-		}
-		'TotalDays'
-		{
-			# Return days with double precision
-			return $ElapsedTime.Elapsed.TotalDays
-			
-			break
-		}
-		'TotalHours'
-		{
-			# Return hours with double precision
-			return $ElapsedTime.Elapsed.TotalHours
-			
-			break
-		}
-		'TotalMinutes'
-		{
-			# Return minutes with double precision
-			return $ElapsedTime.Elapsed.TotalMinutes
-			
-			break
-		}
-		'TotalSeconds'
-		{
-			# Return seconds with double precision
-			return $ElapsedTime.Elapsed.TotalSeconds
-			
-			break
-		}
-		'TotalMilliseconds'
-		{
-			# Return milliseconds with double precision
-			return $ElapsedTime.Elapsed.TotalMilliseconds
-			
-			break
-		}
-	}
+function Get-ElapsedTime {
+    <#
+        .SYNOPSIS
+        Returns information about elapsed time for a given Stopwatch.
+
+        .DESCRIPTION
+        This function takes a [System.Diagnostics.Stopwatch] object as input and outputs information about elapsed time based on the specified format.
+
+        .PARAMETER ElapsedTime
+        The [System.Diagnostics.Stopwatch] object representing the elapsed time for the given stopwatch.
+
+        .PARAMETER Format
+        Specifies the format for the output. Possible values are "Full", "Days", "Hours", "Minutes", "Seconds", "TotalDays", "TotalHours", "TotalMinutes", "TotalSeconds", "TotalMilliseconds".
+
+        .EXAMPLE
+        PS C:\> Get-ElapsedTime -ElapsedTime $ElapsedTime -Format "Days"
+
+        .OUTPUTS
+        System.TimeSpan, System.Double, System.Int32
+    #>
+
+    [CmdletBinding(DefaultParameterSetName = 'FullOutput')]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Stopwatch]
+        $ElapsedTime,
+
+        [ValidateSet("Full", "Days", "Hours", "Minutes", "Seconds", "TotalDays", "TotalHours", "TotalMinutes", "TotalSeconds", "TotalMilliseconds")]
+        [string]
+        $Format = "Full"
+    )
+
+    switch ($Format) {
+        'Full' {
+            return $ElapsedTime.Elapsed
+        }
+        default {
+            return $ElapsedTime.Elapsed."$Format"
+        }
+    }
 }


### PR DESCRIPTION
Refactored the function to accept just two parameters: 'ElapsedTime' and 'Format'. 'Format' is now constrained using 'ValidateSet' to provide a predefined list of valid options, allowing users to easily select from available formats. This simplifies the code by reducing the switch statement to only two cases. Additionally, removed unnecessary 'break' statements after 'return', as the 'return' statement already terminates the function immediately.